### PR TITLE
Adds cookies to router cache bypass list

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -15,6 +15,14 @@
             - 'wordpress_test_cookie'
             - '/^wp-settings-/'
             - '/^wp-postpass/'
+            - '/^woocommerce_items_in_cart/'
+            - '/^woocommerce_cart_hash/'
+            - '/^wp_woocommerce_session_/'
+            - '/^woocommerce_recently_viewed/'
+            - '/store_notice/'
+            - '/woocommerce_snooze_suggestions__/'
+            - '/woocommerce_dismissed_suggestions__/'
+            - '/tk_ai/'
 
 "https://www.{default}/":
     type: redirect


### PR DESCRIPTION
The cookies in this PR need to be added to the router bypass list otherwise a few WooCommerce related functionality such as adding to cart break for anonymous users.

List of cookies can be found in https://docs.woocommerce.com/document/woocommerce-cookies/